### PR TITLE
Fix API key env resolution to prevent front-end connectivity breaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,13 @@
 # AI Studio automatically injects this at runtime from user secrets.
 # Users configure this via the Secrets panel in the AI Studio UI.
 GEMINI_API_KEY="MY_GEMINI_API_KEY"
+VITE_GEMINI_API_KEY="MY_GEMINI_API_KEY"
 
 # APP_URL: The URL where this applet is hosted.
 # AI Studio automatically injects this at runtime with the Cloud Run service URL.
 # Used for self-referential links, OAuth callbacks, and API endpoints.
 APP_URL="MY_APP_URL"
+
+# OPENROUTER_API_KEY / VITE_OPENROUTER_API_KEY: Optional for OpenRouter matching mode.
+OPENROUTER_API_KEY="MY_OPENROUTER_API_KEY"
+VITE_OPENROUTER_API_KEY="MY_OPENROUTER_API_KEY"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ View your app in AI Studio: https://ai.studio/apps/47dca51f-e993-40d5-b79d-88c53
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set `VITE_GEMINI_API_KEY` in `.env.local` to your Gemini API key (you can also keep `GEMINI_API_KEY` for AI Studio compatibility)
 3. Run the app:
    `npm run dev`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,10 +36,14 @@ interface Skill {
 export default function App() {
   const [images, setImages] = useState<ImageItem[]>([]);
   const [skills, setSkills] = useState<Skill[]>([]);
+  const env = (import.meta as any).env ?? {};
+  const fallbackProcessEnv = typeof process !== 'undefined' ? process.env ?? {} : {};
+  const defaultGeminiApiKey = env.VITE_GEMINI_API_KEY || env.GEMINI_API_KEY || fallbackProcessEnv.GEMINI_API_KEY || fallbackProcessEnv.API_KEY || '';
+  const defaultOpenRouterApiKey = env.VITE_OPENROUTER_API_KEY || env.OPENROUTER_API_KEY || fallbackProcessEnv.OPENROUTER_API_KEY || '';
 
   // Initialize Gemini AI
   const getAIInstance = () => {
-    const key = geminiApiKey || process.env.API_KEY || process.env.GEMINI_API_KEY || '';
+    const key = geminiApiKey || defaultGeminiApiKey;
     return new GoogleGenAI({ apiKey: key });
   };
   const [currentPrompt, setCurrentPrompt] = useState('');
@@ -1280,7 +1284,7 @@ export default function App() {
             return JSON.parse(response.text);
           } else {
             // OpenRouter Logic... (Keep existing)
-            const apiKey = openRouterApiKey || process.env.OPENROUTER_API_KEY;
+            const apiKey = openRouterApiKey || defaultOpenRouterApiKey;
             if (!apiKey) throw new Error("请先填写 OpenRouter API Key");
             const contentParts: any[] = [ { type: "text", text: prompt } ];
             currentImagesBatch.forEach(img => {


### PR DESCRIPTION
### Motivation
- Avoid runtime failures and missing API keys in the browser Vite environment caused by direct `process.env.*` access, which can break Gemini/OpenRouter connectivity.

### Description
- Add safe environment resolution in `src/App.tsx` using `import.meta.env` with a guarded `process.env` fallback and expose `defaultGeminiApiKey` and `defaultOpenRouterApiKey` variables.
- Replace direct `process.env` lookups with the new `defaultGeminiApiKey`/`defaultOpenRouterApiKey` in the Gemini AI initialization and OpenRouter matching flow (`getAIInstance` and OpenRouter API call).
- Update `.env.example` to include `VITE_GEMINI_API_KEY`, `VITE_OPENROUTER_API_KEY` and `OPENROUTER_API_KEY` entries so local Vite setups can provide keys.
- Update `README.md` to instruct developers to set `VITE_GEMINI_API_KEY` for local development while keeping `GEMINI_API_KEY` compatibility for AI Studio.

### Testing
- Ran `npm install`, which completed successfully.
- Ran `npm run lint` (which runs `tsc --noEmit`), and TypeScript checks passed.
- Ran `npm run build` (`vite build`), which completed successfully (build succeeded; only chunk-size warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b15f37f88328b36b40940daded6c)